### PR TITLE
fix: login form padding

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -256,8 +256,12 @@ main {
 }
 
 .loginPaper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   margin: 24px;
   width: 20%;
+  padding: 20px;
 }
 
 .fullWidth {


### PR DESCRIPTION
This PR changes the login form by adding some padding and centering the login button.

Before:
![form_before](https://user-images.githubusercontent.com/435066/38159139-5113c754-3457-11e8-8ca5-b082e0a1e915.PNG)

After:
![form_after](https://user-images.githubusercontent.com/435066/38159140-5349e756-3457-11e8-8190-483308feda6c.PNG)
